### PR TITLE
Suggest to use Image-Charts instead of deprecated Google Image Charts

### DIFF
--- a/graph.py
+++ b/graph.py
@@ -27,7 +27,7 @@ def build_graph(graph_id):
   FINISH_URL = '/complete_upload/%s' % graph_id
   blobstore_url = blobstore.create_upload_url(FINISH_URL)
 
-  url = 'https://chart.googleapis.com/chart'
+  url = 'https://image-charts.com/chart'
   data = {
     'cht': 'gv:%s' % g.graph_type,
     'chl': g.dot,

--- a/resources/templates/about.html
+++ b/resources/templates/about.html
@@ -1,10 +1,10 @@
    {% extends "base.html" %}
    {% block content %}
    <h2>About this Site</h2>
-    <p>This site runs on <a href="https://developers.google.com/appengine/docs/whatisgoogleappengine">Google App Engine</a> 
-    and uses templates from the <a href="http://html5boilerplate.com/">HTML5 Boilerplate</a>, It uses the (deprecated!) 
-    <a href="https://developers.google.com/chart/image/">Google Image Charts API</a> to create charts based on 
-    <a href="http://www.graphviz.org/">GraphViz</a>.
+    <p>This site runs on <a href="https://developers.google.com/appengine/docs/whatisgoogleappengine">Google App Engine</a>
+    and uses templates from the <a href="http://html5boilerplate.com/">HTML5 Boilerplate</a>, It was based on the deprecated
+    <a href="https://developers.google.com/chart/image/">Google Image Charts API</a> to create charts based on
+    <a href="http://www.graphviz.org/">GraphViz</a> but now use the drop-in replacement <a href="https://www.image-charts.com/">Image-Charts API</a> instead.
     <br /><br />
     The source code to this site is open and available <a href="https://github.com/grevian/GraphViz-Site">Here</a>
     </p>

--- a/resources/templates/links.html
+++ b/resources/templates/links.html
@@ -13,8 +13,9 @@
 	<h3>Other Graphing Resources</h3>
 	<ul>
 	 <li><a href="http://dia-installer.de/">Dia - A Simpler point and click program that's useful for graphs</a></li>
-	 <li><a href="http://en.wikipedia.org/wiki/Graph_drawing">Wikipedia's Article on Graph Drawing Theory</a></li>	 
-	</ul>	
+	 <li><a href="http://en.wikipedia.org/wiki/Graph_drawing">Wikipedia's Article on Graph Drawing Theory</a></li>
+	 <li><a href="https://image-charts.com/">Generate graph charts as image to embed inside emails, bots and spreadsheets</a></li>	 
+	</ul>
 	</p>
   {% endblock %}
 


### PR DESCRIPTION
Hello!

As you already now, Google Image charts is deprecated and left a huge hole in the space, it was so easy to use, that's why I've started 2 years ago Image-Charts as a drop-in-replacement (TL;DR: I reverse-engineered Google Image Charts API).

This PR let the user know about a future-proof alternative (while still forever-free!).

PS: I loved the conciseness of your website and even did a backlink from [Image-Charts documentation](https://documentation.image-charts.com/graph-viz-charts/), keep up the good work :+1: