### PR TITLE
Swap chart renderer to cloud run based gv renderer

### DIFF
--- a/graph.py
+++ b/graph.py
@@ -17,7 +17,8 @@ jinja_environment = jinja2.Environment(
 class UserGraph(ndb.Model):
   dot = ndb.TextProperty(indexed=False,required=True)
   image = ndb.BlobKeyProperty(indexed=False, required=False)
-  graph_type = ndb.StringProperty(indexed=False, required=True, choices=['dot', 'neato', 'twopi', 'circo', 'fdp'])
+  graph_type = ndb.StringProperty(indexed=False, required=True, choices=['dot', 'neato', 'twopi', 'circo', 'fdp',
+                                                                         'osage', 'patchwork'])
   created = ndb.DateTimeProperty(auto_now_add=True)
   building = ndb.BooleanProperty(indexed=True, required=True)
   error = ndb.TextProperty(indexed=False, required=False)
@@ -37,9 +38,7 @@ def build_graph(graph_id):
   result = requests.post(url, params=data)
   
   if result.status_code != 200:
-    # g.error = result.text
-    # I really wish Google would provide more meaningful feedback when this fails
-    g.error = 'Failed to generate your graph (Error [%s]), perhaps a syntax error?' % result.status_code
+    g.error = 'Failed to generate your graph (Error [%s]): %s' % (result.status_code, result.text)
     g.building = False
     g.put()
   else:

--- a/graph.py
+++ b/graph.py
@@ -27,7 +27,7 @@ def build_graph(graph_id):
   FINISH_URL = '/complete_upload/%s' % graph_id
   blobstore_url = blobstore.create_upload_url(FINISH_URL)
 
-  url = 'https://chart.googleapis.com/chart'
+  url = 'https://gv-renderer-tad6oyng7q-uc.a.run.app/chart'
   data = {
     'cht': 'gv:%s' % g.graph_type,
     'chl': g.dot,

--- a/resources/templates/graph.html
+++ b/resources/templates/graph.html
@@ -14,6 +14,8 @@
                 <option value="twopi" {% if method == 'twopi' %}selected{% endif %}>twopi</option>
                 <option value="circo" {% if method == 'circo' %}selected{% endif %}>circo</option>
                 <option value="fdp" {% if method == 'fdp' %}selected{% endif %}>fdp</option>
+                <option value="osage" {% if method == 'osage' %}selected{% endif %}>osage</option>
+                <option value="patchwork" {% if method == 'patchwork' %}selected{% endif %}>patchwork</option>
             </select> (Just use trial and error to find the method you think works best)
         </div>
         <div class="form-group">


### PR DESCRIPTION
I finally got around to standing up my own renderer, see https://github.com/grevian/graphviz-renderer-web for details, so target it with the sites renderer

This is deployed to http://clrun-dot-grevian-graphviz.appspot.com/graph right now and can be tested there

TODO
- [x] Test all examples
- [x] Expose new supported graph types
- [x] Expose better error messages
